### PR TITLE
Fix path to point to current package

### DIFF
--- a/bench_network/main.go
+++ b/bench_network/main.go
@@ -13,7 +13,7 @@ import "C"
 
 import (
 	"fmt"
-	"github.com/Determinant/salticidae-go"
+	"github.com/ava-labs/salticidae-go"
 	"os"
 	"unsafe"
 )


### PR DESCRIPTION
When following building instructions the make process errors out with;

```
source scripts/env.sh && go build -o build/bench_network github.com/ava-labs/salticidae-go/bench_network
bench_network/main.go:16:2: cannot find package "github.com/Determinant/salticidae-go" in any of:
        /usr/lib/golang/src/github.com/Determinant/salticidae-go (from $GOROOT)
        ***/workspace/src/github.com/Determinant/salticidae-go (from $GOPATH)
make: *** [Makefile:18: build/bench_network] Error 1
```

This PR fixes the error by correcting the package path from the fork Determinant/salticidae-go.

Whilst this PR merges into master, I note that branch `max-msg-size-limit` is the branch being used when building gecko, so it too would need updating.